### PR TITLE
fix: subgraph name 'New Subgraph' is unclear

### DIFF
--- a/example_workflows/LTX2.3_FF_LF_rtx_video.json
+++ b/example_workflows/LTX2.3_FF_LF_rtx_video.json
@@ -1145,7 +1145,7 @@
         },
         "revision": 0,
         "config": {},
-        "name": "New Subgraph",
+        "name": "LTXV First-Last Frame Generation",
         "inputNode": {
           "id": -10,
           "bounding": [


### PR DESCRIPTION
This PR addresses the following issue in `example_workflows/LTX2.3_FF_LF_rtx_video.json`: subgraph name 'New Subgraph' is unclear.

## Changes
- `example_workflows/LTX2.3_FF_LF_rtx_video.json`: subgraph name 'New Subgraph' is unclear.

## Details
```diff
--- a/example_workflows/LTX2.3_FF_LF_rtx_video.json
+++ b/example_workflows/LTX2.3_FF_LF_rtx_video.json
@@ -1,1 +1,1 @@
-"name": "New Subgraph"
+"name": "LTXV First-Last Frame Generation"
```

## Tests
- `tests/test_example_workflows.py`

```diff
--- /dev/null
+++ b/tests/test_example_workflows.py
@@ -0,0 +1,47 @@
+import json
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).parent.parent / "example_workflows" / "LTX2.3_FF_LF_rtx_video.json"
+
+
+class TestLTX23FFLFRtxVideoWorkflow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(WORKFLOW, "r", encoding="utf-8") as f:
+            cls.data = json.load(f)
+
+    def _find_node_by_title(self, title):
+        for node in self.data["nodes"]:
+            if node.get("title") == title:
+                return node
+        self.fail(f"Node with title {title!r} not found")
+
+    def test_negative_prompt_not_contaminated(self):
+        negatives = self._find_node_by_title("Negatives")
+        prompt = negatives["widgets_values"][0]
+        self.assertNotIn(
+            "makes a left turn and then rides down a city street.",
+            prompt,
+        )
+        self.assertNotIn(
+            "A motorcycle drives down a short alley",
+            prompt,
+        )
+
+    def test_no_typo_in_first_frame_group_title(self):
+        for group in self.data["definitions"]["subgraphs"][0]["groups"]:
+            self.assertNotEqual(group["title"], "FIrst Frame")
+
+    def test_subgraph_name_is_descriptive(self):
+        subgraph = self.data["definitions"]["subgraphs"][0]
+        self.assertNotEqual(subgraph["name"], "New Subgraph")
+        self.assertTrue(subgraph["name"].strip())
+
+
+if __name__ == "__main__":
+    unittest.main()
```